### PR TITLE
Fix a flaky test.

### DIFF
--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -526,6 +526,7 @@ class TestMagicMethods(unittest.TestCase):
 		self.assertEqual(who.born, [b1, b2])
 
 	def test_not_multiple_instance(self):
+		model.factory.auto_id_type = 'int-per-segment'
 		who = model.Person()
 		n = model.Name(content="Test")
 		who.identified_by = n


### PR DESCRIPTION
# What is the purpose of the change
- This PR is to fix a flaky test `tests/test_model.py::TestMagicMethods::test_not_multiple_instance` after running `tests/test_model.py::TestAutoIdentifiers::test_bad_autoid`, but passes when it is run in isolation.

# Reproduce the test failure
- Run the following command:
```
python -m pytest tests/test_model.py::TestAutoIdentifiers::test_bad_autoid tests/test_model.py::TestMagicMethods::test_not_multiple_instance
```
# Why it fails
- `model.factory.auto_id_type` is polluted after `tests/test_model.py::TestAutoIdentifiers::test_bad_autoid`

# Fix
- Reset `model.factory.auto_id_type` to `int-per-segment`